### PR TITLE
Fixed issue when running multiple calls

### DIFF
--- a/lib/http2.rb
+++ b/lib/http2.rb
@@ -282,7 +282,7 @@ class Http2
     #Possible to give custom host-argument.
     _args = args[:host] ? args : @args
     headers["Host"] = _args[:host]
-    headers["Host"] << ":#{_args[:port]}" unless _args[:port] && [80,443].include?(_args[:port].to_i)
+    headers["Host"] += ":#{_args[:port]}" unless _args[:port] && [80,443].include?(_args[:port].to_i)
     
     if !@args.key?(:encoding_gzip) or @args[:encoding_gzip]
       headers["Accept-Encoding"] = "gzip"


### PR DESCRIPTION
If running multiple calls using the same http2 object, it didn't work
out as expected due to << was affecting the :host.
