### PR TITLE
Fixed issue with length of unicode characters

### DIFF
--- a/lib/http2.rb
+++ b/lib/http2.rb
@@ -383,7 +383,7 @@ class Http2
       puts "Doing post." if @debug
       
       header_str = "#{method} /#{args[:url]} HTTP/1.1#{@nl}"
-      header_str << self.header_str({"Content-Length" => praw.length, "Content-Type" => content_type}.merge(self.default_headers(args)), args)
+      header_str << self.header_str({"Content-Length" => praw.bytesize, "Content-Type" => content_type}.merge(self.default_headers(args)), args)
       header_str << @nl
       header_str << praw
       header_str << @nl


### PR DESCRIPTION
The Content-Length provided the wrong length in case of content included UTF-8 characters.

This confuses the destination server, which then cannot properly parse the received data as it's corrupted.

It seems like the issue have occurred by ruby 1.9+:
https://github.com/blatyo/bencodr/issues/2
