### PR TITLE
Convert for using .to_json

### DIFF
--- a/lib/http2.rb
+++ b/lib/http2.rb
@@ -370,7 +370,7 @@ class Http2
     
     if args[:json]
       require "json" unless ::Kernel.const_defined?(:JSON)
-      praw = JSON.generate(args[:json])
+      praw = args[:json].to_json
       content_type = "application/json"
     elsif args[:post].is_a?(String)
       praw = args[:post]


### PR DESCRIPTION
This will support additional cases of encoding, like where the expected result only is a single object (like a string).

Compared to what other implementations does (like .to_json, JSON.dump, JavaScript's JSON.stringify), it seems to be acceptable to do it this way.

However, not been able to locate the RFCs - at the time of writing - specifying what is right or wrong, but would be nice to have confirmed or declined.
