### PR TITLE
Include support for additional settings

### DIFF
--- a/include/response_reader.rb
+++ b/include/response_reader.rb
@@ -106,7 +106,7 @@ private
     url = url.gsub(/\A\//, "")
 
     args = @http2.args
-           .except(:ssl, :port)
+           .reject { |k, v| [:ssl, :port].include? k }
            .merge(host: uri.host)
     args[:ssl] = true if uri.scheme == "https"
     args[:port] = uri.port if uri.port

--- a/include/response_reader.rb
+++ b/include/response_reader.rb
@@ -106,7 +106,7 @@ private
     url = url.gsub(/\A\//, "")
 
     args = @http2.args
-           .except(:port)
+           .except(:ssl, :port)
            .merge(host: uri.host)
     args[:ssl] = true if uri.scheme == "https"
     args[:port] = uri.port if uri.port

--- a/include/response_reader.rb
+++ b/include/response_reader.rb
@@ -105,7 +105,9 @@ private
     url << "?#{uri.query}" if uri.query.to_s.length > 0
     url = url.gsub(/\A\//, "")
 
-    args = @http2.args.merge(host: uri.host)
+    args = @http2.args
+           .except(:port)
+           .merge(host: uri.host)
     args[:ssl] = true if uri.scheme == "https"
     args[:port] = uri.port if uri.port
 

--- a/include/response_reader.rb
+++ b/include/response_reader.rb
@@ -105,10 +105,8 @@ private
     url << "?#{uri.query}" if uri.query.to_s.length > 0
     url = url.gsub(/\A\//, "")
 
-    args = {host: uri.host}
+    args = @http2.args.merge(host: uri.host)
     args[:ssl] = true if uri.scheme == "https"
-    args[:ssl_skip_verify] = @http2.args[:ssl_skip_verify]
-    args[:debug] = @http2.args[:debug]
     args[:port] = uri.port if uri.port
 
     return [url, args]


### PR DESCRIPTION
Minor improvements for #23.

Not all args was included in the follow-redirect request, not taking advantage of provided settings such as proxy, basic_auth, extra_headers, user_agent etc.

This simplifies inclusion as well.